### PR TITLE
Implement HDAUDIO_BUS_INTERFACE_BDL handling

### DIFF
--- a/sklhdaudbus/buspdo.cpp
+++ b/sklhdaudbus/buspdo.cpp
@@ -522,6 +522,16 @@ Bus_CreatePdo(
             return status;
         }
 
+        HDAUDIO_BUS_INTERFACE_BDL busInterfaceBDL = HDA_BusInterfaceBDL(pdoData);
+        WDF_QUERY_INTERFACE_CONFIG_INIT(&qiConfig,
+            (PINTERFACE)&busInterfaceBDL,
+            &GUID_HDAUDIO_BUS_INTERFACE_BDL,
+            NULL);
+        status = WdfDeviceAddQueryInterface(hChild, &qiConfig);
+        if (!NT_SUCCESS(status)) {
+            return status;
+        }
+
         HDAUDIO_BUS_INTERFACE_V2 busInterface2 = HDA_BusInterfaceV2(pdoData);
         WDF_QUERY_INTERFACE_CONFIG_INIT(&qiConfig,
             (PINTERFACE)&busInterface2,

--- a/sklhdaudbus/driver.h
+++ b/sklhdaudbus/driver.h
@@ -57,6 +57,7 @@ NTSTATUS HDA_WaitForTransfer(
 HDAUDIO_BUS_INTERFACE HDA_BusInterface(PVOID Context);
 HDAUDIO_BUS_INTERFACE_V2 HDA_BusInterfaceV2(PVOID Context);
 HDAUDIO_BUS_INTERFACE_V3 HDA_BusInterfaceV3(PVOID Context);
+HDAUDIO_BUS_INTERFACE_BDL HDA_BusInterfaceBDL(PVOID Context);
 
 #define IS_BXT(ven, dev) (ven == VEN_INTEL && dev == 0x5a98)
 

--- a/sklhdaudbus/fdo.cpp
+++ b/sklhdaudbus/fdo.cpp
@@ -369,10 +369,11 @@ Fdo_EvtDevicePrepareHardware(
     maxAddr.QuadPart = fdoCtx->is64BitOK ? MAXULONG64 : MAXULONG32;
 
     fdoCtx->posbuf = MmAllocateContiguousMemory(PAGE_SIZE, maxAddr);
-    RtlZeroMemory(fdoCtx->posbuf, PAGE_SIZE);
     if (!fdoCtx->posbuf) {
         return STATUS_NO_MEMORY;
     }
+
+    RtlZeroMemory(fdoCtx->posbuf, PAGE_SIZE);
 
     fdoCtx->rb = (UINT8 *)MmAllocateContiguousMemory(PAGE_SIZE, maxAddr);
     if (!fdoCtx->rb) {
@@ -419,6 +420,9 @@ Fdo_EvtDevicePrepareHardware(
                 }
 
                 stream->bdl = (PHDAC_BDLENTRY)MmAllocateContiguousMemory(BDL_SIZE, maxAddr);
+                if (stream->bdl) {
+                    RtlZeroMemory(stream->bdl, BDL_SIZE);
+                }
             }
 
             SklHdAudBusPrint(DEBUG_LEVEL_INFO, DBG_INIT,

--- a/sklhdaudbus/fdo.h
+++ b/sklhdaudbus/fdo.h
@@ -27,6 +27,12 @@ typedef struct _HDAC_STREAM_CALLBACK {
     PVOID CallbackContext;
 } HDAC_STREAM_CALLBACK, *PHDAC_STREAM_CALLBACK;
 
+typedef struct _HDAC_ISR_CALLBACK {
+    BOOLEAN IOC;
+    PHDAUDIO_BDL_ISR IsrCallback;
+    PVOID CallbackContext;
+} HDAC_ISR_CALLBACK, *PHDAC_ISR_CALLBACK;
+
 typedef struct _HDAC_BDLENTRY {
     UINT32 lowAddr;
     UINT32 highAddr;
@@ -41,6 +47,7 @@ typedef struct _HDAC_STREAM {
     PMDL mdlBuf;
     UINT32* posbuf;
 
+	PVOID dmaBuf;
     HDAC_BDLENTRY* bdl;
 
     BOOLEAN stripe;
@@ -62,6 +69,8 @@ typedef struct _HDAC_STREAM {
 
     PKEVENT registeredEvents[MAX_NOTIF_EVENTS];
     HDAC_STREAM_CALLBACK registeredCallbacks[MAX_NOTIF_EVENTS];
+
+    HDAC_ISR_CALLBACK isr;
 
     BOOLEAN running;
     BOOLEAN irqReceived;

--- a/sklhdaudbus/hdac_controller.cpp
+++ b/sklhdaudbus/hdac_controller.cpp
@@ -356,8 +356,14 @@ int hda_stream_interrupt(PFDO_CONTEXT fdoCtx, unsigned int status) {
 			stream_write8(stream, SD_STS, SD_INT_MASK);
 			handled |= 1 << stream->idx;
 
-			if (sd_status & SD_INT_COMPLETE)
+			if (sd_status & SD_INT_COMPLETE) {
+				if (stream->isr.IOC && stream->isr.IsrCallback) {
+					stream->isr.IsrCallback(
+								stream->isr.CallbackContext,
+								sd_status);
+				}
 				stream->irqReceived = TRUE;
+			}
 		}
 	}
 	return handled;

--- a/sklhdaudbus/hdaudio.cpp
+++ b/sklhdaudbus/hdaudio.cpp
@@ -838,6 +838,161 @@ NTSTATUS HDA_UnregisterNotificationCallback(
 	return registered ? STATUS_SUCCESS : STATUS_INVALID_PARAMETER;
 }
 
+NTSTATUS HDA_SetupDmaEngineWithBdl(
+	_In_ PVOID _context,
+	_In_ HANDLE Handle,
+	_In_ ULONG BufferLength,
+	_In_ ULONG Lvi,
+	_In_ PHDAUDIO_BDL_ISR Isr,
+	_In_ PVOID Context,
+	_Out_ PUCHAR StreamId,
+	_Out_ PULONG FifoSize)
+{
+	if (KeGetCurrentIrql() > PASSIVE_LEVEL) {
+		return STATUS_UNSUCCESSFUL;
+	}
+
+	PPDO_DEVICE_DATA devData = (PPDO_DEVICE_DATA)_context;
+	if (!devData->FdoContext) {
+		return STATUS_NO_SUCH_DEVICE;
+	}
+
+	PHDAC_STREAM stream = (PHDAC_STREAM)Handle;
+	if (stream->PdoContext != devData) {
+		return STATUS_INVALID_HANDLE;
+	}
+
+	if (stream->running) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	if (!stream->bdl) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	if (!stream->dmaBuf) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	WdfInterruptAcquireLock(devData->FdoContext->Interrupt);
+
+	stream->bufSz = BufferLength;
+	stream->numBlocks = Lvi;
+
+	RtlZeroMemory(&stream->isr, sizeof(HDAC_ISR_CALLBACK));
+	stream->isr.IOC = TRUE;
+	stream->isr.IsrCallback = Isr;
+	stream->isr.CallbackContext = Context;
+
+	hdac_stream_reset(stream);
+	hdac_stream_setup(stream);
+
+	*StreamId = stream->streamTag;
+	*FifoSize = stream->fifoSize;
+
+	WdfInterruptReleaseLock(devData->FdoContext->Interrupt);
+
+	return STATUS_SUCCESS;
+}
+
+NTSTATUS HDA_FreeContiguousDmaBuffer(
+	_In_ PVOID _context,
+	_In_ HANDLE Handle)
+{
+	if (KeGetCurrentIrql() > PASSIVE_LEVEL) {
+		return STATUS_UNSUCCESSFUL;
+	}
+
+	PPDO_DEVICE_DATA devData = (PPDO_DEVICE_DATA)_context;
+	if (!devData->FdoContext) {
+		return STATUS_NO_SUCH_DEVICE;
+	}
+
+	PHDAC_STREAM stream = (PHDAC_STREAM)Handle;
+	if (stream->PdoContext != devData) {
+		return STATUS_INVALID_HANDLE;
+	}
+
+	if (stream->running) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	if (!stream->bdl) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	if (!stream->dmaBuf) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	WdfInterruptAcquireLock(devData->FdoContext->Interrupt);
+
+	stream_write32(stream, SD_BDLPL, 0);
+	stream_write32(stream, SD_BDLPU, 0);
+	stream_write32(stream, SD_CTL, 0);
+
+	RtlZeroMemory(&stream->isr, sizeof(HDAC_ISR_CALLBACK));
+
+	WdfInterruptReleaseLock(devData->FdoContext->Interrupt);
+
+	MmFreeContiguousMemory(stream->dmaBuf);
+	stream->dmaBuf = NULL;
+
+	return STATUS_SUCCESS;
+}
+
+NTSTATUS HDA_AllocateContiguousDmaBuffer(
+	_In_ PVOID _context,
+	_In_ HANDLE Handle,
+	_In_ ULONG RequestedBufferSize,
+	_Out_ PVOID* DataBuffer,
+	_Out_ PHDAUDIO_BUFFER_DESCRIPTOR* BdlBuffer)
+{
+	if (KeGetCurrentIrql() > PASSIVE_LEVEL) {
+		return STATUS_UNSUCCESSFUL;
+	}
+
+	PPDO_DEVICE_DATA devData = (PPDO_DEVICE_DATA)_context;
+	if (!devData->FdoContext) {
+		return STATUS_NO_SUCH_DEVICE;
+	}
+
+	PHDAC_STREAM stream = (PHDAC_STREAM)Handle;
+	if (stream->PdoContext != devData) {
+		return STATUS_INVALID_HANDLE;
+	}
+
+	if (stream->running) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	if (stream->dmaBuf) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+	if (!stream->bdl) {
+		return STATUS_INVALID_DEVICE_REQUEST;
+	}
+
+    PHYSICAL_ADDRESS maxAddr;
+    maxAddr.QuadPart = devData->FdoContext->is64BitOK ? MAXULONG64 : MAXULONG32;
+
+    stream->dmaBuf = MmAllocateContiguousMemory(RequestedBufferSize, maxAddr);
+    if (!stream->dmaBuf) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(stream->dmaBuf, RequestedBufferSize);
+
+	WdfInterruptAcquireLock(devData->FdoContext->Interrupt);
+
+	*DataBuffer = stream->dmaBuf;
+	*BdlBuffer = (PHDAUDIO_BUFFER_DESCRIPTOR)stream->bdl;
+
+	WdfInterruptReleaseLock(devData->FdoContext->Interrupt);
+
+	return STATUS_SUCCESS;
+}
+
 HDAUDIO_BUS_INTERFACE_V2 HDA_BusInterfaceV2(PVOID Context) {
 	HDAUDIO_BUS_INTERFACE_V2 busInterface;
 	RtlZeroMemory(&busInterface, sizeof(HDAUDIO_BUS_INTERFACE_V2));
@@ -917,6 +1072,35 @@ HDAUDIO_BUS_INTERFACE HDA_BusInterface(PVOID Context) {
 	busInterface.ChangeBandwidthAllocation = HDA_ChangeBandwidthAllocation;
 	busInterface.AllocateDmaBuffer = HDA_AllocateDmaBuffer;
 	busInterface.FreeDmaBuffer = HDA_FreeDmaBuffer;
+	busInterface.FreeDmaEngine = HDA_FreeDmaEngine;
+	busInterface.SetDmaEngineState = HDA_SetDmaEngineState;
+	busInterface.GetWallClockRegister = HDA_GetWallClockRegister;
+	busInterface.GetLinkPositionRegister = HDA_GetLinkPositionRegister;
+	busInterface.RegisterEventCallback = HDA_RegisterEventCallback;
+	busInterface.UnregisterEventCallback = HDA_UnregisterEventCallback;
+	busInterface.GetDeviceInformation = HDA_GetDeviceInformation;
+	busInterface.GetResourceInformation = HDA_GetResourceInformation;
+
+	return busInterface;
+}
+
+HDAUDIO_BUS_INTERFACE_BDL HDA_BusInterfaceBDL(PVOID Context)
+{
+	HDAUDIO_BUS_INTERFACE_BDL busInterface;
+	RtlZeroMemory(&busInterface, sizeof(HDAUDIO_BUS_INTERFACE_BDL));
+
+	busInterface.Size = sizeof(HDAUDIO_BUS_INTERFACE_BDL);
+	busInterface.Version = 0x0100;
+	busInterface.Context = Context;
+	busInterface.InterfaceReference = (PINTERFACE_REFERENCE)WdfDeviceInterfaceReferenceNoOp;
+	busInterface.InterfaceDereference = (PINTERFACE_DEREFERENCE)WdfDeviceInterfaceDereferenceNoOp;
+	busInterface.TransferCodecVerbs = HDA_TransferCodecVerbs;
+	busInterface.AllocateCaptureDmaEngine = HDA_AllocateCaptureDmaEngine;
+	busInterface.AllocateRenderDmaEngine = HDA_AllocateRenderDmaEngine;
+	busInterface.ChangeBandwidthAllocation = HDA_ChangeBandwidthAllocation;
+	busInterface.AllocateContiguousDmaBuffer = HDA_AllocateContiguousDmaBuffer;
+	busInterface.SetupDmaEngineWithBdl = HDA_SetupDmaEngineWithBdl;
+	busInterface.FreeContiguousDmaBuffer = HDA_FreeContiguousDmaBuffer;
 	busInterface.FreeDmaEngine = HDA_FreeDmaEngine;
 	busInterface.SetDmaEngineState = HDA_SetDmaEngineState;
 	busInterface.GetWallClockRegister = HDA_GetWallClockRegister;


### PR DESCRIPTION
- Implement 3 new routines: AllocateContiguousDmaBuffer(), FreeContiguousDmaBuffer() and SetupDmaEngineWithBdl().
- Call PHDAUDIO_BDL_ISR callback initialized in SetupDmaEngineWithBdl() on stream interrupt in case it was passed by the caller.
- Fix null memory initialization of positional buffer: zero-initialize it only in case it's successfully allocated.
- Properly zero-initialize BDL (buffer descriptor list) buffer, to avoid uninitialized kernel memory leakage. It's used by AllocateContiguousDmaBuffer() as well.

Required by some 3rd-party audio codec drivers like Realtek HD.
Tested succesfully by Justin Miller (DarkFire01) in Windows 10 with several audio codec drivers and confirmed to be working.