### PR TITLE
Use KeStallExecutionProcessor() to handle stream reset delays

### DIFF
--- a/sklhdaudbus/hdac_stream.cpp
+++ b/sklhdaudbus/hdac_stream.cpp
@@ -41,7 +41,7 @@ void hdac_stream_reset(PHDAC_STREAM stream) {
 	dma_run_state = stream_read8(stream, SD_CTL) & SD_CTL_DMA_START;
 
 	stream_update8(stream, SD_CTL, 0, SD_CTL_STREAM_RESET);
-	udelay(3);
+	KeStallExecutionProcessor(3);
 	int timeout = 300;
 
 	UCHAR val;
@@ -53,7 +53,7 @@ void hdac_stream_reset(PHDAC_STREAM stream) {
 
 	val &= ~SD_CTL_STREAM_RESET;
 	stream_write8(stream, SD_CTL, val);
-	udelay(3);
+	KeStallExecutionProcessor(3);
 
 	timeout = 300;
 	/* waiting for hardware to report that the stream is out of reset */


### PR DESCRIPTION
Handle stream reset delays via KeStallExecutionProcessor() instead of KeDelayExecutionThread().
Pros of using it:
 - Does exactly the same thing (and has the same purpose) as KeDelayExecutionThread().
 - Works at any IRQL, unlike KeDelayExecutionThread(), which is limited to APC/DISPATCH only.
 - Works better for short delays (up to 50 microseconds).
 - Confirmed to be imported from HAL and used in the corresponding HdaController::ResetDmaEngine() method of Vista SP2 hdaudbus.sys as well, while KeDelayExecutionThread() is used to handle all other delays.

As result, this fixes several problems like sanity checks failures (asserts and bugchecks) during stream reset (e. g., when pausing/stopping the playback or closing the app which plays the sound) when testing the driver in ReactOS, because of calling KeDelayExecutionThread() at wrong IRQL.
KeDelayExecutionThread() calls work in Windows correctly only because release build of Windows contains no additional sanity checks, unlike debug one, same as debug build of ReactOS. But calling it at the IRQL which is higher than maximum supported by that routine, is wrong anyway.