### PR TITLE
Misc fixes for XP-era codecs

### DIFF
--- a/sklhdaudbus/hdac_stream.cpp
+++ b/sklhdaudbus/hdac_stream.cpp
@@ -171,6 +171,5 @@ void hdac_stream_setup(PHDAC_STREAM stream) {
 	/* set the interrupt enable bits in the descriptor control register */
 	stream_update32(stream, SD_CTL, 0, SD_INT_MASK);
 
-	stream->fifoSize = 0;
 	stream->fifoSize = stream_read16(stream, SD_FIFOSIZE) + 1;
 }

--- a/sklhdaudbus/hdaudio.cpp
+++ b/sklhdaudbus/hdaudio.cpp
@@ -928,7 +928,7 @@ HDA_SetupDmaEngineWithBdl(
 	WdfInterruptAcquireLock(devData->FdoContext->Interrupt);
 
 	stream->bufSz = BufferLength;
-	stream->numBlocks = (UINT16)Lvi;
+	stream->numBlocks = (UINT16)(Lvi + 1);
 
 	RtlZeroMemory(&stream->isr, sizeof(HDAC_ISR_CALLBACK));
 	stream->isr.IOC = TRUE;


### PR DESCRIPTION
- Increment Last Valid Index (LVI) in `SetupDmaEngineWithBdl()` by `1` when writing it to the stream handle. MSDN says LVI always starts from `1`, not `0`, so it needs an additional increment for the last element in BDL list. This completely fixes sound disortions for left audio output channel, which plays the sound properly now.
- Remove unnecessary zero-initialization of `fifoSize` in `hdac_stream_setup()`. It's properly initialized on the next line anyway, so zeroing does not affect an initialization in any way.

This fixes all sound disortions for left output channel when performing an audio playback with multiple codecs compatible with Windows XP, like Realtek <2.74 and older versions of SigmaTel (#17). So now lot of cracks, pops and chopping are gone. To be tested with other similar codecs too.
However, it does not fix the right channel distorted sound bug yet. Currently, only left speaker is playing sound properly, but right one does not.
Tested with the current sklhdaudbus driver + KMDF from Windows 10 15xx in ReactOS 0.4.16-dev build.

How it sounds before:
[ROS-playback-before.mp3](https://github.com/user-attachments/files/26724854/ROS-playback-before.mp3)
and after:
[ROS-playback-after.mp3](https://github.com/user-attachments/files/26724892/ROS-playback-after.mp3)

Recording has been done from real hardware (Asus-F5R notebook with onboard Realtek ALC660 audio controller). This configuration is confirmed to be fixed at least.