### PR TITLE
Misc fixes for XP era codecs part 2

### DIFF
--- a/sklhdaudbus/hdac_stream.cpp
+++ b/sklhdaudbus/hdac_stream.cpp
@@ -112,7 +112,7 @@ UINT16 hdac_format(PHDAC_STREAM stream) {
 			return 0;
 		format |= channels - 1;
 
-		switch (stream->streamFormat.ContainerSize) {
+		switch (stream->streamFormat.ValidBitsPerSample) {
 		case 8:
 			format |= AC_FMT_BITS_8;
 			break;


### PR DESCRIPTION
- Use `ValidBitsPerSample` instead of `ContainerSize` to get the actual BPS value, since according to MSDN, only it contains correct value which is left-justified within the container. This fixes streaming problems in the case when the value of `ValidBitsPerSample` is different from the one from `ContainerSize` (e. g., for Realtek R2.74 WDM codec, `ContainerSize` is `32` while `ValidBitsPerSample` is `24` in that case).

This fixes sound distortions for the right channel too, when using this driver in pair with Realtek 2.74 codec in Windows XP SP3 and ReactOS 0.4.16-dev. So now playback works absolutely fine from both output channels and has no any other bugs, for Realtek codec at least.
Also retested several times and confirmed: generic HdAudio.sys codec from Vista SP2 still works same fine, so this fix does not cause any regressions for NT6-compatible codecs. Sure other Vista+ codecs should work the same too.
To be tested with other similar XP-era codecs as well.
This completely resolves issue #17.